### PR TITLE
🧙 Update CODEOWNERS to new team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Guessed from teams who have admin access in github
-* @Financial-Times/infradelivery
+* @Financial-Times/edo


### PR DESCRIPTION
## Why?

The ID team is now the Edo team. I have changed the Github team name to reflect this. As a result, the codeowners need to be changed from the old team name to the new one.

## What?

- Replaced references(if any found) of `infradelivery` to `edo` in the CODEOWNERS file.

### Anything in particular you'd like to highlight to reviewers?

This PR is created automatically using a script. Please double check the changes, since it might have made some silly changes.

We have used the `[skip ci]` tag in the commit message to prevent an overload of concurrent CircleCI builds. If you would like to run your CI pipeline on this PR, you can make an empty commit on this branch to trigger CI before merging the PR.

`git commit --allow-empty -m "Trigger CI"`